### PR TITLE
Changed name from AlgIO to alg.io

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,7 +45,7 @@ class WelcomeScreen extends StatelessWidget {
             height: 250,
           ),
           Text(
-            'AlgIO',
+            'alg.io',
             style: Theme.of(context).textTheme.headline,
           ),
           Divider(height: 20),
@@ -102,7 +102,7 @@ class _HomeScreenState extends State<HomeScreen> {
           elevation: 10,
           backgroundColor: Theme.of(context).backgroundColor,
           title: Text(
-            'AlgIO',
+            'alg.io',
             style: titleFont,
           )),
       body: _buildTopics(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -15,6 +15,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
@@ -35,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.13"
   convert:
     dependency: transitive
     description:
@@ -115,7 +122,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.8"
   meta:
     dependency: transitive
     description:
@@ -204,7 +211,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
@@ -232,14 +239,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.17"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:
@@ -255,5 +262,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
Thoughts about this change? The idea is that alg.io is mimicking those .io websites, and maybe our host name could be www.alg.io.